### PR TITLE
Update magicsuggest.js

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -550,6 +550,7 @@
                 }
             }
             this.input.attr('placeholder', (cfg.selectionPosition === 'inner' && this.getValue().length > 0) ? '' : cfg.placeholder);
+            this.input.css({width: '100%'});
         };
 
         /**


### PR DESCRIPTION
fix bug 
after call the clear() function . the input placeholder can't be shown totally.  i see the input width has been changed too small after call clear.  so i change the input width.
